### PR TITLE
Provides fallback to default storybook docs.story or docs.component params.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,5 @@ A note[^1]
 };
 
 ```
+
+However, but default Storybook supports individual [stories for components](https://storybook.js.org/docs/api/doc-blocks/doc-block-description#writing-descriptions) so it will automatically fallback to the Storybook docs values if a description parameter is not found.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storybook-addon-description",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Add description to panel",
   "keywords": [
     "storybook-addons",

--- a/src/components/PanelContent.tsx
+++ b/src/components/PanelContent.tsx
@@ -8,7 +8,13 @@ interface PanelContentProps {
 }
 
 export const PanelContent: React.FC<PanelContentProps> = (props) => {
-  const description =  useParameter<string>("description");
+  const paramsDescription =  useParameter<string>("description");
+
+  const docs = useParameter<{ description: { story?: string; component?: string; } }>('docs')
+  const storyDescription = docs && docs.description && docs.description.story;
+  const componentDescription = docs && docs.description && docs.description.component;
+  
+  const description = paramsDescription || storyDescription || componentDescription || null;
 
   if (!description) return  null;
 


### PR DESCRIPTION
Hi, great feature, really surprised storybook doesn't have this by default. However it introduces a new parameter when storybook [already supports](https://storybook.js.org/docs/api/doc-blocks/doc-block-description#writing-descriptions) individual story descriptions in the `docs` param.

This change allows the use of the already defined story docs description instead of using another defined parameter since this will allow the already configured storybook stories with doc descriptions to be shown. But it also maintains backwards compatibility with your work by prioritising the parameter introduced by this component first if configured, but otherwise falling back to the storybook default `docs` params.